### PR TITLE
Slider pointer :after pseudo-element now gets animation transition applied.

### DIFF
--- a/src/ngx-slider/lib/slider.component.scss
+++ b/src/ngx-slider/lib/slider.component.scss
@@ -282,6 +282,10 @@
 
       .ngx-slider-pointer {
         transition: all linear $animationDuration;
+
+        &:after {
+          transition: all linear $animationDuration;
+        }
       }
 
       .ngx-slider-bubble {


### PR DESCRIPTION
The smaller circle within the pointer was not getting CSS transitions applied.

Closes #297.