### PR TITLE
Export SliderComponent in public API so we can benefit from TypeScript when using @ViewChild #294

### DIFF
--- a/src/ng5-slider/lib/public_api.json
+++ b/src/ng5-slider/lib/public_api.json
@@ -7,6 +7,12 @@
       "file": "./slider.module"
     },
     {
+      "what": [
+        "SliderComponent"
+      ],
+      "file": "./slider.component"
+    },
+    {
       "what": "*",
       "file": "./change-context"
     },


### PR DESCRIPTION
Suggested fix for:
Export SliderComponent in public API so we can benefit from TypeScript when using @ViewChild #294