### PR TITLE
Fix disabling form controls via reactive forms; reset no longer marks as dirty

### DIFF
--- a/e2e/reactive-form-simple-slider.spec.ts
+++ b/e2e/reactive-form-simple-slider.spec.ts
@@ -34,6 +34,10 @@ function getValueTextElement(page: Page): Locator {
   return page.locator('p:nth-child(1)');
 }
 
+function getResetTextElement(page: Page): Locator {
+  return page.locator('p:nth-child(2)');
+}
+
 function getFormButton(page: Page, id: string): Locator {
   return page.locator(`button#${id}`);
 }
@@ -64,6 +68,7 @@ test('reactive form simple slider after dragging the slider pointer updates the 
 
   await expect(getSliderPointerLabel(page)).toHaveText('50');
   await expect(getValueTextElement(page)).toHaveText('Value: 50');
+  await expect(getResetTextElement(page)).toHaveText('Dirty: true')
 
   await expect(getSliderPointer(page)).toHaveRelativeLocationWithoutMargins({ x: 147, y: 21 }, { relativeTo: getSlider(page) });
   await expect(getSliderPointerLabel(page)).toHaveRelativeLocationWithoutMargins({ x: 151, y: -3 }, { relativeTo: getSlider(page) });
@@ -77,6 +82,7 @@ test('reactive form simple slider after dragging the slider pointer and after re
 
   await expect(getSliderPointerLabel(page)).toHaveText('100');
   await expect(getValueTextElement(page)).toHaveText('Value: 100');
+  await expect(getResetTextElement(page)).toHaveText('Dirty: false')
 
   await expect(getSliderPointer(page)).toHaveRelativeLocationWithoutMargins({ x: 294, y: 21 }, { relativeTo: getSlider(page) });
   await expect(getSliderPointerLabel(page)).toHaveRelativeLocationWithoutMargins({ x: 293, y: -3 }, { relativeTo: getSlider(page) });

--- a/e2e/reactive-form-simple-slider.spec.ts
+++ b/e2e/reactive-form-simple-slider.spec.ts
@@ -34,10 +34,9 @@ function getValueTextElement(page: Page): Locator {
   return page.locator('p:nth-child(1)');
 }
 
-function getFormResetButton(page: Page): Locator {
-  return page.locator('button');
+function getFormButton(page: Page, id: string): Locator {
+  return page.locator(`button#${id}`);
 }
-
 
 test('reactive form simple slider initial state displays starting values in labels and positions the slider elements correctly', async ({ page }) => {
   await setUp(page);
@@ -61,7 +60,7 @@ test('reactive form simple slider initial state displays starting values in labe
 test('reactive form simple slider after dragging the slider pointer updates the pointer to new position', async ({ page }) => {
   await setUp(page);
 
-  await mouseDragRelative(getSliderPointer(page), {offsetX: -146, offsetY: 0});
+  await mouseDragRelative(getSliderPointer(page), { offsetX: -146, offsetY: 0 });
 
   await expect(getSliderPointerLabel(page)).toHaveText('50');
   await expect(getValueTextElement(page)).toHaveText('Value: 50');
@@ -73,12 +72,49 @@ test('reactive form simple slider after dragging the slider pointer updates the 
 test('reactive form simple slider after dragging the slider pointer and after resetting the form reverts the slider to starting state', async ({ page }) => {
   await setUp(page);
 
-  await mouseDragRelative(getSliderPointer(page), {offsetX: -146, offsetY: 0});
-  await getFormResetButton(page).click();
+  await mouseDragRelative(getSliderPointer(page), { offsetX: -146, offsetY: 0 });
+  await getFormButton(page, 'reset').click();
 
   await expect(getSliderPointerLabel(page)).toHaveText('100');
   await expect(getValueTextElement(page)).toHaveText('Value: 100');
 
   await expect(getSliderPointer(page)).toHaveRelativeLocationWithoutMargins({ x: 294, y: 21 }, { relativeTo: getSlider(page) });
   await expect(getSliderPointerLabel(page)).toHaveRelativeLocationWithoutMargins({ x: 293, y: -3 }, { relativeTo: getSlider(page) });
+});
+
+test('reactive form simple slider after disabling the form control the slider should not move when dragging the pointer', async ({ page }) => {
+  await setUp(page);
+
+  await expect(getSliderFloorLabel(page)).toHaveText('0');
+  await expect(getSliderCeilLabel(page)).toHaveText('250');
+  await expect(getSliderPointerLabel(page)).toHaveText('100');
+  await expect(getValueTextElement(page)).toHaveText('Value: 100');
+
+  // Check that dragging the slider works
+  await mouseDragRelative(getSliderPointer(page), { offsetX: -146, offsetY: 0 });
+
+  await expect(getSliderPointerLabel(page)).toHaveText('50');
+  await expect(getValueTextElement(page)).toHaveText('Value: 50');
+
+  // Reset the slider
+  await getFormButton(page, 'reset').click();
+
+  await expect(getSliderPointerLabel(page)).toHaveText('100');
+  await expect(getValueTextElement(page)).toHaveText('Value: 100');
+
+  await getFormButton(page, 'disable').click();
+
+  // After disabling the slider, check that it cannot be moved
+  await mouseDragRelative(getSliderPointer(page), { offsetX: -146, offsetY: 0 });
+
+  await expect(getSliderPointerLabel(page)).toHaveText('100');
+  await expect(getValueTextElement(page)).toHaveText('Value: 100');
+
+  await getFormButton(page, 'enable').click();
+
+  // After enabling the slider, check that it can be moved again
+  await mouseDragRelative(getSliderPointer(page), { offsetX: -146, offsetY: 0 });
+
+  await expect(getSliderPointerLabel(page)).toHaveText('50');
+  await expect(getValueTextElement(page)).toHaveText('Value: 50');
 });

--- a/src/demo-app/app/snippets/reactive-form-simple-slider/reactive-form-simple-slider.component.template.html
+++ b/src/demo-app/app/snippets/reactive-form-simple-slider/reactive-form-simple-slider.component.template.html
@@ -1,3 +1,9 @@
-<p>Value: {{sliderControl.value}}</p>
-<p><button (click)="resetForm()">Reset</button></p>
+<p>Value: {{ sliderControl.value }}</p>
+
+<p>
+  <button id="reset" (click)="resetForm()">Reset</button>
+  <button id="disable" (click)="disable()" [disabled]="sliderControl.disabled">Disable</button>
+  <button id="enable" (click)="enable()" [disabled]="sliderControl.enabled">Enable</button>
+</p>
+
 <ngx-slider [options]="options" [formControl]="sliderControl"></ngx-slider>

--- a/src/demo-app/app/snippets/reactive-form-simple-slider/reactive-form-simple-slider.component.template.html
+++ b/src/demo-app/app/snippets/reactive-form-simple-slider/reactive-form-simple-slider.component.template.html
@@ -1,4 +1,5 @@
 <p>Value: {{ sliderControl.value }}</p>
+<p>Dirty: {{ sliderControl.dirty }}</p>
 
 <p>
   <button id="reset" (click)="resetForm()">Reset</button>

--- a/src/demo-app/app/snippets/reactive-form-simple-slider/reactive-form-simple-slider.component.ts
+++ b/src/demo-app/app/snippets/reactive-form-simple-slider/reactive-form-simple-slider.component.ts
@@ -14,6 +14,14 @@ export class ReactiveFormSimpleSliderComponent {
     ceil: 250,
   };
 
+  disable(): void {
+    this.sliderControl.disable();
+  }
+
+  enable(): void {
+    this.sliderControl.enable();
+  }
+
   resetForm(): void {
     this.sliderControl.reset(100);
   }

--- a/src/ngx-slider/lib/slider.component.ts
+++ b/src/ngx-slider/lib/slider.component.ts
@@ -114,10 +114,12 @@ class ModelChange extends ModelValues {
 }
 
 class InputModelChange extends ModelChange {
+  controlAccessorChange: boolean;
   internalChange: boolean;
 }
 
 class OutputModelChange extends ModelChange {
+  controlAccessorChange: boolean;
   userEventInitiated: boolean;
 }
 
@@ -429,6 +431,7 @@ export class SliderComponent
       this.inputModelChangeSubject.next({
         value: this.value,
         highValue: this.highValue,
+        controlAccessorChange: false,
         forceChange: false,
         internalChange: false,
       });
@@ -461,6 +464,7 @@ export class SliderComponent
       highValue: this.highValue,
       forceChange: false,
       internalChange: false,
+      controlAccessorChange: true,
     });
   }
 
@@ -638,6 +642,7 @@ export class SliderComponent
     this.outputModelChangeSubject.next({
       value: this.value,
       highValue: this.highValue,
+      controlAccessorChange: false,
       userEventInitiated: true,
       forceChange: false,
     });
@@ -649,6 +654,7 @@ export class SliderComponent
     this.inputModelChangeSubject.next({
       value: this.value,
       highValue: this.highValue,
+      controlAccessorChange: false,
       forceChange: false,
       internalChange: true,
     });
@@ -694,6 +700,7 @@ export class SliderComponent
     this.outputModelChangeSubject.next({
       value: normalisedModelChange.value,
       highValue: normalisedModelChange.highValue,
+      controlAccessorChange: modelChange.controlAccessorChange,
       forceChange: normalisationChange,
       userEventInitiated: false,
     });
@@ -705,6 +712,12 @@ export class SliderComponent
       this.valueChange.emit(modelChange.value);
       if (this.range) {
         this.highValueChange.emit(modelChange.highValue);
+      }
+
+      // If this change is coming from a control accessor (i.e. angular called `writeValue`)
+      // then we do not want to call the angular callbacks.
+      if (modelChange.controlAccessorChange) {
+        return;
       }
 
       if (!ValueHelper.isNullOrUndefined(this.onChangeCallback)) {
@@ -817,6 +830,7 @@ export class SliderComponent
       this.outputModelChangeSubject.next({
         value: this.value,
         highValue: this.highValue,
+        controlAccessorChange: false,
         forceChange: true,
         userEventInitiated: false,
       });

--- a/src/ngx-slider/lib/slider.component.ts
+++ b/src/ngx-slider/lib/slider.component.ts
@@ -478,6 +478,10 @@ export class SliderComponent
   public setDisabledState(isDisabled: boolean): void {
     this.viewOptions.disabled = isDisabled;
     this.updateDisabledState();
+
+    if (this.initHasRun) {
+      this.manageEventsBindings();
+    }
   }
 
   public setAriaLabel(ariaLabel: string): void {


### PR DESCRIPTION
Currently, it is not possible to disable the slider by disabling or enabling a form control through reactive forms (see #223). When changing the enabled state, the slider will appear to be disabled, but it actually isn't.

This pull request fixes that (fixes #223).

I've also added a fix so that the slider no longer emits changes to angular when they come from angular, i.e. when the value is updated by calling something like `control.reset(0)`, the slider no longer calls the reactive forms callbacks for 'changed' and 'touched'. Previously, these would cause the controls to become dirty and touched again when the controls were reset (fixes #255).